### PR TITLE
Update aws-bedrock.md

### DIFF
--- a/docs/configuration/llm/aws-bedrock.md
+++ b/docs/configuration/llm/aws-bedrock.md
@@ -11,7 +11,7 @@ Configurable parameters:
 | region_name    | region name  |  ap-northeast-1 | 
 | aws_access_key_id | aws access key id | HS21qAAAAAAAAAAA |
 | aws_secret_access_key | aws access secret key | HS21qAAAAAAAAAAA |
-| model | https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html | anthropic.claude-v2.1 |
+| model | https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html | anthropic.claude-v2:1 |
 | max_tokens | max output token count | 1024 |
 | temperature |  What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.We generally recommend altering this or top_p but not both. | 0.7 |
 
@@ -27,7 +27,7 @@ Configuration example:
             "region_name": "ap-northeast-1",
             "aws_access_key_id": "TAAAAAAAAAAAAa",
             "aws_secret_access_key": "TAAAAAAAAAAAAa",
-            "model": "anthropic.claude-v2.1",
+            "model": "anthropic.claude-v2:1",
             "max_tokens": 1024,
             "temperature": 0.7
         }


### PR DESCRIPTION
modelid  "anthropic.claude-v2:1" is right,not "anthropic.claude-v2.1"

https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html#model-ids-arns

Anthropic | Claude | 2.0 | anthropic.claude-v2
-- | -- | -- | --
Anthropic | Claude | 2.1 | anthropic.claude-v2:1
Anthropic | Claude 3 Sonnet | 1.0 | anthropic.claude-3-sonnet-20240229-v1:0
Anthropic | Claude 3.5 Sonnet | 1.0 | anthropic.claude-3-5-sonnet-20240620-v1:0
Anthropic | Claude 3 Haiku | 1.0 | anthropic.claude-3-haiku-20240307-v1:0
Anthropic | Claude 3 Opus | 1.0 | anthropic.claude-3-opus-20240229-v1:0
Anthropic | Claude Instant | 1.x | anthropic.claude-instant-v1

